### PR TITLE
Increase screenshot height for webtop

### DIFF
--- a/amd/helpers.py
+++ b/amd/helpers.py
@@ -29,7 +29,7 @@ def mobile_screenshot(browser,Image):
     if path.exists(Image):
         os.remove(Image)
     logger.info(browser)
-    browser.set_window_size(380, 660) #the trick
+    browser.set_window_size(380, 900) #the trick
     time.sleep(2)
     browser.save_screenshot(Image)
     browser.close()


### PR DESCRIPTION
660 is not enough for webtop even when there are 2 children. More height is needed for more.
So I assume 900 will be good for 3-4 children.